### PR TITLE
Fix TypeError in aa_omniscience_prompt

### DIFF
--- a/src/lighteval/tasks/tasks/aa_omniscience.py
+++ b/src/lighteval/tasks/tasks/aa_omniscience.py
@@ -233,12 +233,12 @@ def record_to_sample(record):
     return Sample(input=query, target=target, metadata={"domain": record["domain"], "topic": record["topic"]})
 
 
-def aa_omniscience_prompt(record):
+def aa_omniscience_prompt(record, task_name: str = None):
     query = OMNISCIENCE_ANSWER_PROMPT.format(domain=record["domain"], topic=record["topic"])
     query += "\n\n" + record["question"]
 
     return Doc(
-        task_name="aa_omniscience",
+        task_name=task_name,
         query=query,
         choices=[record["answer"]],
         gold_index=0,


### PR DESCRIPTION
This PR fixes a TypeError in the `aa_omniscience` task where the `task_name` argument was missing from the prompt function signature.

Fixes #3