### PR TITLE
Fix RecursionError in imdb_contrastset_prompt

### DIFF
--- a/src/lighteval/tasks/tasks/imdb.py
+++ b/src/lighteval/tasks/tasks/imdb.py
@@ -35,7 +35,7 @@ def imdb_prompt(line, task_name: str = None):
 
 def imdb_contrastset_prompt(line, task_name: str = None):
     if line["contrast_input"] is None or line["contrast_references"] is None:
-        return imdb(line)
+        return imdb_prompt(line)
 
     return Doc(
         task_name=task_name,


### PR DESCRIPTION
This PR fixes a bug in `imdb_contrastset_prompt` where an incorrect call pattern could lead to infinite recursion. The function now correctly delegates to `imdb_prompt`.

Fixes #9