### PR TITLE
Fix schema validation in olympiad_bench Doc.specific

### DIFF
--- a/src/lighteval/tasks/tasks/olympiade_bench.py
+++ b/src/lighteval/tasks/tasks/olympiade_bench.py
@@ -242,7 +242,7 @@ def olympiad_bench_prompt(line, task_name: str = None):
         choices=[choice],
         gold_index=0,
         instruction=instruction,
-        specific={},
+        specific=None,
     )
 
 


### PR DESCRIPTION
This PR fixes a schema validation error in `olympiad_bench` by removing an empty dictionary assignment to the `Doc.specific` field, which caused issues during dataset saving.

Fixes #19