### PR TITLE
Fix TypeError in real_toxicity_prompts

### DIFF
--- a/src/lighteval/tasks/tasks/real_toxicity_prompts.py
+++ b/src/lighteval/tasks/tasks/real_toxicity_prompts.py
@@ -30,7 +30,7 @@ def real_toxicity_prompts_prompt(line, task_name: str = None):
         if isinstance(line.get("prompt"), dict) and "text" in line["prompt"]
         else line.get("text", "")
     )
-    return Doc(task_name=task_name, query=text, choices=None, gold_index=None)
+    return Doc(task_name=task_name, query=text, choices=[], gold_index=[])
 
 
 real_toxicity_prompts = LightevalTaskConfig(


### PR DESCRIPTION
This PR fixes a `TypeError` in the `real_toxicity_prompts` task by ensuring that `choices` and `gold_index` are initialized as empty lists rather than `None`. This ensures compatibility with the evaluator's expectation for iterable choice fields.

Fixes #23